### PR TITLE
bugfix: enable handling of GPU-backed arrays

### DIFF
--- a/napari_features/_features.py
+++ b/napari_features/_features.py
@@ -6,7 +6,7 @@ import pandas
 from ._dock_widget import DockWidget
 from .generator import Generator
 from ._feature_selection_widget import FeatureSelectionWidget
-
+import numpy as np
 
 def features(
         image: napari.layers.Image,
@@ -23,7 +23,7 @@ def features(
 
     viewer.window.add_dock_widget(feature_selection_widget)
 
-    generator = Generator(masks.data, image.data, feature_selection_widget.selected)
+    generator = Generator(np.asarray(masks.data), np.asarray(image.data), feature_selection_widget.selected)
 
     data = pandas.DataFrame([feature for feature in generator], columns=generator.columns)
 


### PR DESCRIPTION
Hi @0x00b1 ,

this closes #12 by calling `np.asarray()` on image and label image before passing them to the generator.

Let me know if this makes sense!

Best,
Robert
