### PR TITLE
remove empty dock widget

### DIFF
--- a/napari_features/_features.py
+++ b/napari_features/_features.py
@@ -13,12 +13,6 @@ def features(
         masks: napari.layers.Labels,
         viewer: napari.Viewer
 ):
-    dock_widget = DockWidget()
-
-    viewer.window.add_dock_widget(dock_widget, area="bottom")
-
-    viewer.window.add_dock_widget(dock_widget)
-
     feature_selection_widget = FeatureSelectionWidget()
 
     viewer.window.add_dock_widget(feature_selection_widget)


### PR DESCRIPTION
Hi @0x00b1 ,

this removes an empty dock widget that was a bit suspiciously  hanging around in napari

Best,
Robert

![image](https://user-images.githubusercontent.com/12660498/130841696-d5cc91ba-6584-4db9-9be5-d2615d2179d8.png)

