### PR TITLE
put summary in core metadata

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,4 +1,3 @@
 authors:
   - name: "Allen Goodman"
     orcid: "0000-0002-6434-2320"
-summary: "extensible, general-purpose feature extraction"

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Operating System :: OS Independent
     License :: OSI Approved :: MIT License
+summary = extensible, general-purpose feature extraction
 description = extracts image and object features
 license = MIT
 long_description = file: README.md


### PR DESCRIPTION
hey @0x00b1, I'm trying to clean up some metadata for various napari plugins using `napari/config.yml`.  This moves your summary to the standard location. Note that you can use `.napari/config.yaml` if you'd like to _override_ how your page appears on the hub, but you should mimimally populate the official sources for  [standard metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) 